### PR TITLE
3 namespace separator

### DIFF
--- a/ThoR/Alloy/Syntax/namespaceSeparator.lean
+++ b/ThoR/Alloy/Syntax/namespaceSeparator.lean
@@ -19,12 +19,12 @@ namespace Alloy
   deriving Repr
 
   /--
-  A syntax repreaentation of an assert declaration.
+  A syntax repreaentation of an namespaceSeparator
   -/
   declare_syntax_cat namespaceSeparator
   declare_syntax_cat namespaceSeparatorExtension
-  syntax "/" str : namespaceSeparatorExtension
-  syntax str (namespaceSeparatorExtension)*: namespaceSeparator
+  syntax "/" ident : namespaceSeparatorExtension
+  syntax ident (namespaceSeparatorExtension)*: namespaceSeparator
 
   instance : ToString namespaceSeparator where
     toString (ns : namespaceSeparator) : String :=
@@ -43,20 +43,20 @@ namespace Alloy
       (ns : TSyntax `namespaceSeparator)
       : namespaceSeparator := Id.run do
         match ns with
-          | `(namespaceSeparator| $ns:str) =>
-            return {representedNamespace := (mkIdent ns.getString.toName)}
+          | `(namespaceSeparator| $ns:ident) =>
+            return {representedNamespace := (mkIdent ns.getId)}
 
           | `(namespaceSeparator|
-                $ns:str $nse:namespaceSeparatorExtension*) =>
-            let nseString :=
+                $ns:ident $nse:namespaceSeparatorExtension*) =>
+            let finalName :=
               nse.foldl (fun result elem =>
                 match elem with
-                  | `(namespaceSeparatorExtension| / $ns:str) =>
-                    result.append ns.getString
+                  | `(namespaceSeparatorExtension| / $ns:ident) =>
+                    result.appendAfter s!".{ns.getId}"
                   | _ => result
-              ) ns.getString
+              ) ns.getId
 
-            return {representedNamespace := (mkIdent nseString.toName)}
+            return {representedNamespace := (mkIdent finalName)}
 
           | _ => default
 

--- a/ThoR/Alloy/Syntax/namespaceSeparator.lean
+++ b/ThoR/Alloy/Syntax/namespaceSeparator.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2024 RheinMain University of Applied Sciences
+Released under license as described in the file LICENSE.
+Authors: s. file CONTRIBUTORS
+-/
+import ThoR.Basic
+open Lean
+
+/-
+  Represents an alloy-like namespace
+-/
+namespace Alloy
+
+  /--
+  This Structure represents the ident value of the alloy-like namespace
+  -/
+  structure namespaceSeparator where
+    (representedNamespace : Ident)
+  deriving Repr
+
+  /--
+  A syntax repreaentation of an assert declaration.
+  -/
+  declare_syntax_cat namespaceSeparator
+  declare_syntax_cat namespaceSeparatorExtension
+  syntax "/" str : namespaceSeparatorExtension
+  syntax str (namespaceSeparatorExtension)*: namespaceSeparator
+
+  instance : ToString namespaceSeparator where
+    toString (ns : namespaceSeparator) : String :=
+      s!"namespaceSeparator : {ns.representedNamespace.getId}"
+
+  instance : Inhabited namespaceSeparator where
+    default := {representedNamespace := default}
+
+  namespace namespaceSeparator
+
+    /-- Generates a String representation from the type -/
+    def toString (ns : namespaceSeparator) : String := ToString.toString ns
+
+    /-- Generates a type representation from the TSyntax -/
+    def toType
+      (ns : TSyntax `namespaceSeparator)
+      : namespaceSeparator := Id.run do
+        match ns with
+          | `(namespaceSeparator| $ns:str) =>
+            return {representedNamespace := (mkIdent ns.getString.toName)}
+
+          | `(namespaceSeparator|
+                $ns:str $nse:namespaceSeparatorExtension*) =>
+            let nseString :=
+              nse.foldl (fun result elem =>
+                match elem with
+                  | `(namespaceSeparatorExtension| / $ns:str) =>
+                    result.append ns.getString
+                  | _ => result
+              ) ns.getString
+
+            return {representedNamespace := (mkIdent nseString.toName)}
+
+          | _ => default
+
+    def toTerm
+      (ns : namespaceSeparator)
+      : TSyntax `term := Unhygienic.run do
+        return ← `(term| $(ns.representedNamespace))
+
+  end namespaceSeparator
+
+end Alloy

--- a/ThoR/Shared/Syntax/Relation/expr.lean
+++ b/ThoR/Shared/Syntax/Relation/expr.lean
@@ -36,6 +36,10 @@ namespace Shared
         (expression1 : expr) →
         (expression2 : expr) →
         expr
+    | namespace_call:
+      (expression1 : expr) →
+      (expression2 : expr) →
+      expr
     | string_rb : (string : String) → expr
   deriving Repr
 
@@ -47,6 +51,9 @@ namespace Shared
   syntax ident : expr
   syntax "(" expr ")" : expr
   syntax:60 expr:60 binRelOp expr:60 : expr
+
+  --namespace caller with /
+  syntax expr "/" expr : expr
 
   -- dotjoin has higher precendence
   syntax:70 expr:70 dotjoin expr:70 : expr
@@ -72,6 +79,8 @@ namespace Shared
           expr.binaryRelOperation op2 e3 e4 =>
           (op1 == op2) && (compare e1 e3) && (compare e2 e4)
         | expr.string_rb s1, expr.string_rb s2 => s1 == s2
+        | expr.namespace_call e1 e2, expr.namespace_call e3 e4 =>
+          (compare e1 e3) && (compare e2 e4)
         | _, _ => false
 
     /--
@@ -86,6 +95,8 @@ namespace Shared
           (e1.toString) ++ (op.toString) ++ (e2.toString)
         | expr.dotjoin dj e1 e2 =>
           s!"{e1.toString}{dj}{e2.toString}"
+        | expr.namespace_call e1 e2 =>
+          s!"{e1.toString}/{e2.toString}"
         | expr.string_rb s => s
 
     /--
@@ -101,6 +112,8 @@ namespace Shared
           expr.unaryRelOperation op (e.toStringRb)
         | expr.dotjoin dj e1 e2 =>
           expr.dotjoin dj (e1.toStringRb) (e2.toStringRb)
+        | expr.namespace_call e1 e2 =>
+          expr.namespace_call (e1.toStringRb) (e2.toStringRb)
         | e => e
 
     /--
@@ -118,6 +131,8 @@ namespace Shared
             `(expr| $(e1.toSyntax blockName):expr $(op.toSyntax):binRelOp $(e2.toSyntax blockName):expr)
           | expr.dotjoin dj e1 e2 =>
             `(expr|$(e1.toSyntax blockName):expr $(dj.toSyntax):dotjoin $(e2.toSyntax blockName):expr)
+          | expr.namespace_call e1 e2 =>
+            `(expr|$(e1.toSyntax blockName):expr / $(e2.toSyntax blockName):expr)
           -- FIXME In der folgenden Zeile fehlt noch das $rb -> Macht das Probleme?
           | expr.string_rb s => `(expr| @$(mkIdent s!"{blockName}.vars.{s}".toName):ident)
 
@@ -166,6 +181,12 @@ namespace Shared
                   blockName quantorNames
                   )
               ))
+
+          | expr.namespace_call e1 e2 =>
+
+            let term1 := e1.toTerm inBLock blockName quantorNames
+            let term2 := e2.toTerm inBLock blockName quantorNames
+            `(term| $term1.$(mkIdent s!"{term2}".toName))
 
           | expr.string_rb s => do
             `((@$(mkIdent s.toName) $(baseType.getIdent) _ _))
@@ -254,6 +275,13 @@ namespace Shared
             (expr.toType subExpr1)
             (expr.toType subExpr2)
 
+        | `(expr |
+          $subExpr1:expr
+          /
+          $subExpr2:expr) =>
+          expr.namespace_call
+          (expr.toType subExpr1)
+          (expr.toType subExpr2)
 
         | _ => expr.const constant.none -- unreachable
         decreasing_by -- subexprs are obv smaller than the expression they are part of
@@ -268,6 +296,7 @@ namespace Shared
         | expr.string s => [s]
         | expr.binaryRelOperation _ e1 e2 => (e1.getReqVariables) ++ (e2.getReqVariables)
         | expr.unaryRelOperation _ e => e.getReqVariables
+        | expr.dotjoin _ e1 e2 => (e1.getReqVariables) ++ (e2.getReqVariables)
         | _ => []
 
   end expr

--- a/ThoR/Shared/Syntax/Relation/expr.lean
+++ b/ThoR/Shared/Syntax/Relation/expr.lean
@@ -103,6 +103,15 @@ namespace Shared
           expr.dotjoin dj (e1.toStringRb) (e2.toStringRb)
         | e => e
 
+    instance : ToString expr where
+    toString : expr -> String := fun e => e.toString
+
+    instance : BEq expr where
+      beq : expr -> expr -> Bool := fun e1 e2 => e1.compare e2
+
+    instance : Inhabited expr where
+      default := expr.const constant.none
+
     /--
     Generates a syntax representation of the type
     -/
@@ -191,7 +200,7 @@ namespace Shared
     /--
     Parses the given syntax to the type
     -/
-    def toType (e : TSyntax `expr) : expr :=
+    partial def toType (e : TSyntax `expr) : expr :=
       match e with
         | `(expr | ( $e:expr )) => expr.toType e
         | `(expr |
@@ -255,9 +264,6 @@ namespace Shared
             (expr.toType subExpr2)
 
         | _ => expr.const constant.none -- unreachable
-        decreasing_by -- subexprs are obv smaller than the expression they are part of
-          all_goals simp_wf
-          repeat admit
 
     /--
     Gets the required variables for the type
@@ -271,11 +277,5 @@ namespace Shared
         | _ => []
 
   end expr
-
-  instance : ToString expr where
-    toString : expr -> String := fun e => e.toString
-
-  instance : BEq expr where
-    beq : expr -> expr -> Bool := fun e1 e2 => e1.compare e2
 
 end Shared

--- a/ThoR/Test/Alloy/01_section.lean
+++ b/ThoR/Test/Alloy/01_section.lean
@@ -13,11 +13,17 @@ This file tests the alloy section
 
 -/
 
-alloy empty_section
+alloy empty_sec
 end
 
 alloy module empty_module_section
 end
+
+#alloy name/uses/alloy_like/separator
+  sig A {}
+end
+
+#check name.uses.alloy_like.separator.vars.A
 
 /-With Content to create the namespace-/
 #alloy

--- a/ThoR/Test/Alloy/alloyBlockTests.lean
+++ b/ThoR/Test/Alloy/alloyBlockTests.lean
@@ -15,15 +15,6 @@ end
   }
 end
 
-#alloy x2
-  sig a {
-    r : x/a
-  }
-end
-
-#check x.vars.a
-#check x2.vars.r
-
 #alloy b2
   sig A extends B{
     r: B

--- a/ThoR/Test/Alloy/alloyBlockTests.lean
+++ b/ThoR/Test/Alloy/alloyBlockTests.lean
@@ -15,6 +15,15 @@ end
   }
 end
 
+#alloy x2
+  sig a {
+    r : x/a
+  }
+end
+
+#check x.vars.a
+#check x2.vars.r
+
 #alloy b2
   sig A extends B{
     r: B


### PR DESCRIPTION
added alloy like namespace seperator, which can (so far) be used in alloy block names